### PR TITLE
support proxy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.434</version>
+        <version>1.443</version>
     </parent>
 
     <groupId>org.jvnet.hudson.plugins</groupId>

--- a/src/main/java/hudson/plugins/sitemonitor/SiteMonitorRecorder.java
+++ b/src/main/java/hudson/plugins/sitemonitor/SiteMonitorRecorder.java
@@ -22,6 +22,7 @@
 package hudson.plugins.sitemonitor;
 
 import hudson.Launcher;
+import hudson.ProxyConfiguration;
 import hudson.model.AbstractBuild;
 import hudson.model.BuildListener;
 import hudson.plugins.sitemonitor.model.Result;
@@ -104,7 +105,7 @@ public class SiteMonitorRecorder extends Recorder {
             ctx.init(new KeyManager[0], new TrustManager[] { new DefaultTrustManager() }, new SecureRandom());
             SSLContext.setDefault(ctx);
 
-            HttpsURLConnection connection = (HttpsURLConnection) (new URL(urlString)).openConnection();
+            HttpsURLConnection connection = (HttpsURLConnection) ProxyConfiguration.open(new URL(urlString));
             connection.setHostnameVerifier(new HostnameVerifier() {
                 @Override
                 public boolean verify(String arg0, SSLSession arg1) {
@@ -113,7 +114,7 @@ public class SiteMonitorRecorder extends Recorder {
             });
             return connection;
         } else {
-            return (HttpURLConnection) (new URL(urlString)).openConnection();
+            return (HttpURLConnection) ProxyConfiguration.open(new URL(urlString));
         }
     }
 


### PR DESCRIPTION
This commit add support http proxy to sitemonitor-plugin.

see:
https://issues.jenkins-ci.org/browse/JENKINS-12419
