### PR TITLE
Replace own implementation with Guava and avoid Nullpointer (happens …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,7 @@
 			<plugin>
 				<artifactId>maven-pmd-plugin</artifactId>
 				<configuration>
-					<targetJdk>1.5</targetJdk>
+					<targetJdk>1.6</targetJdk>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvString.java
+++ b/src/main/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvString.java
@@ -24,6 +24,8 @@ package hudson.plugins.sitemonitor.mapper;
 import java.util.List;
 
 import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 
 /**
  * Transform a list of integers to a string comma-separated
@@ -36,13 +38,9 @@ public enum SuccessCodeListToCvString implements Function<List<Integer>, String>
     INSTANCE;
 
     public String apply(List<Integer> list) {
-
-        StringBuffer sb = new StringBuffer();
-        for (Integer successResponseCode : list) {
-            sb.append(successResponseCode).append(",");
+        if(list != null) {
+            return Joiner.on(",").join(list);
         }
-        return sb.toString().replaceFirst(",$", "");
-        
-        
+        return "";
     }
 }

--- a/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
+++ b/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
@@ -12,7 +12,7 @@ public class SuccessCodeListToCvStringTest {
 
     @Test
     public void apply_withOneItem() {
-        List<Integer> list = new ArrayList<>();
+        List<Integer> list = new ArrayList<Integer>();
         list.add(1);
 
         String result = SuccessCodeListToCvString.INSTANCE.apply(list);
@@ -21,7 +21,7 @@ public class SuccessCodeListToCvStringTest {
 
     @Test
     public void apply_withTwoItems() {
-        List<Integer> list = new ArrayList<>();
+        List<Integer> list = new ArrayList<Integer>();
         list.add(1);
         list.add(2);
 
@@ -31,7 +31,7 @@ public class SuccessCodeListToCvStringTest {
 
     @Test
     public void apply_withEmptyList() {
-        List<Integer> list = new ArrayList<>();
+        List<Integer> list = new ArrayList<Integer>();
         String result = SuccessCodeListToCvString.INSTANCE.apply(list);
         Assert.assertEquals("", result);
     }

--- a/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
+++ b/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
@@ -6,8 +6,6 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.*;
-
 public class SuccessCodeListToCvStringTest {
 
     @Test

--- a/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
+++ b/src/test/java/hudson/plugins/sitemonitor/mapper/SuccessCodeListToCvStringTest.java
@@ -1,0 +1,45 @@
+package hudson.plugins.sitemonitor.mapper;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class SuccessCodeListToCvStringTest {
+
+    @Test
+    public void apply_withOneItem() {
+        List<Integer> list = new ArrayList<>();
+        list.add(1);
+
+        String result = SuccessCodeListToCvString.INSTANCE.apply(list);
+        Assert.assertEquals("1", result);
+    }
+
+    @Test
+    public void apply_withTwoItems() {
+        List<Integer> list = new ArrayList<>();
+        list.add(1);
+        list.add(2);
+
+        String result = SuccessCodeListToCvString.INSTANCE.apply(list);
+        Assert.assertEquals("1,2", result);
+    }
+
+    @Test
+    public void apply_withEmptyList() {
+        List<Integer> list = new ArrayList<>();
+        String result = SuccessCodeListToCvString.INSTANCE.apply(list);
+        Assert.assertEquals("", result);
+    }
+
+    @Test
+    public void apply_avoidNullPointer() {
+        String result = SuccessCodeListToCvString.INSTANCE.apply(null);
+        Assert.assertEquals("", result);
+    }
+
+}


### PR DESCRIPTION
…in Jenkins 2:

```
Caused by: java.lang.NullPointerException
	at hudson.plugins.sitemonitor.mapper.SuccessCodeListToCvString.apply(SuccessCodeListToCvString.java:41)
	at hudson.plugins.sitemonitor.SiteMonitorDescriptor.getSuccessResponseCodesCsv(SiteMonitorDescriptor.java:125)
	... 160 more
```

I added a test before refactoring to ensure the same behaviour as before (unless the Nullpointer).