### PR TITLE
Add parameters in URL definition

### DIFF
--- a/src/main/java/hudson/plugins/sitemonitor/SiteMonitorRecorder.java
+++ b/src/main/java/hudson/plugins/sitemonitor/SiteMonitorRecorder.java
@@ -21,6 +21,7 @@
  */
 package hudson.plugins.sitemonitor;
 
+import hudson.EnvVars;
 import hudson.Launcher;
 import hudson.ProxyConfiguration;
 import hudson.model.AbstractBuild;
@@ -165,9 +166,12 @@ public class SiteMonitorRecorder extends Recorder {
             Status status;
             String note = "";
             HttpURLConnection connection = null;
-
+            String url = site.getUrl();
+            final EnvVars env = build.getEnvironment(listener);
+            url = env.expand(url);
+            
             try {
-                connection = getConnection(site.getUrl());
+                connection = getConnection(url);
                 
                 if (site.getTimeout() != null) {
                     connection.setConnectTimeout(site.getTimeout() * MILLISECS_IN_SECS);
@@ -203,7 +207,7 @@ public class SiteMonitorRecorder extends Recorder {
 
             note = "[" + status + "] " + note;
             listener.getLogger().println(
-                    Messages.SiteMonitor_Console_URL() + site.getUrl() + ", "
+                    Messages.SiteMonitor_Console_URL() + url + ", "
                             + Messages.SiteMonitor_Console_ResponseCode() + responseCode + ", "
                             + Messages.SiteMonitor_Console_Status() + status);
 

--- a/src/main/java/hudson/plugins/sitemonitor/SiteMonitorValidator.java
+++ b/src/main/java/hudson/plugins/sitemonitor/SiteMonitorValidator.java
@@ -55,7 +55,8 @@ public class SiteMonitorValidator {
                 if (!url.startsWith("http://") && !url.startsWith("https://")) {
                     validation = FormValidation.error(Messages.SiteMonitor_Error_PrefixOfURL());
                 }
-            } else {
+            //Check if parameter is present in URL    
+            } else if(!url.contains("${")){
                 
                 String internalUrl = url;
 

--- a/src/main/java/hudson/plugins/sitemonitor/mapper/JsonToSiteMapper.java
+++ b/src/main/java/hudson/plugins/sitemonitor/mapper/JsonToSiteMapper.java
@@ -43,7 +43,7 @@ public enum JsonToSiteMapper implements Function<JSONObject, Site>{
         
         String url = json.getString("url");
         
-        if (!url.startsWith("http://") && !url.startsWith("https://")) {
+        if (!url.startsWith("http://") && !url.startsWith("https://") && !url.contains("${")) {
             url = "http://" + url;
         }
         

--- a/src/main/webapp/url.html
+++ b/src/main/webapp/url.html
@@ -1,2 +1,2 @@
 The URL address of the web site to be monitored. URL should start with http:// or https://. 
-By default http:// will be used.
+By default http:// will be used. You can use parameters in URL definition.


### PR DESCRIPTION
This feature is very useful. You can create one job template and use it in different jobs.
I left the correctness of parameters on build creator.